### PR TITLE
Add AES-256-GCM encryption service with Argon2id key derivation

### DIFF
--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,1 @@
+# services package

--- a/backend/app/services/encryption.py
+++ b/backend/app/services/encryption.py
@@ -1,0 +1,173 @@
+"""
+Task 14 — AES-256-GCM Encryption Service
+-----------------------------------------
+Provides encrypt() and decrypt() for vault entry data.
+
+Key derivation: Argon2id (OWASP-recommended parameters)
+Encryption:     AES-256-GCM (authenticated encryption)
+Nonce:          12-byte random, unique per operation, never reused
+Storage format: nonce (12 bytes) || ciphertext || auth_tag (16 bytes)
+                returned as separate values to match the VaultEntry model
+
+SECURITY INVARIANTS:
+  - The encryption key is NEVER stored or logged.
+  - Plaintext is NEVER written to logs or error messages.
+  - A wrong key or corrupted ciphertext raises DecryptionError immediately.
+"""
+
+import os
+import logging
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from argon2.low_level import hash_secret_raw, Type
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Custom exception
+# ---------------------------------------------------------------------------
+
+class DecryptionError(Exception):
+    """
+    Raised when AES-256-GCM authentication tag verification fails.
+    This indicates either a wrong key or corrupted ciphertext.
+    No plaintext or key material is ever included in this exception.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Argon2id parameters (OWASP recommended, as of 2024)
+# https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+# ---------------------------------------------------------------------------
+
+ARGON2_TIME_COST    = 3          # iterations
+ARGON2_MEMORY_COST  = 64 * 1024  # 64 MiB in KiB
+ARGON2_PARALLELISM  = 4          # threads
+ARGON2_HASH_LEN     = 32         # 256-bit output key
+ARGON2_TYPE         = Type.ID    # Argon2id variant
+
+# AES-GCM nonce length (96 bits — the NIST-recommended size for GCM)
+NONCE_SIZE = 12
+
+
+# ---------------------------------------------------------------------------
+# Key derivation
+# ---------------------------------------------------------------------------
+
+def derive_key(master_password: str, salt: bytes) -> bytes:
+    """
+    Derives a 256-bit AES key from the user's master password using Argon2id.
+
+    Args:
+        master_password: The user's plaintext master password.
+        salt:            A unique, persistent per-user salt (stored in the
+                         User.encryption_salt column, NOT the IV/nonce).
+
+    Returns:
+        32-byte derived key (never stored, used only at runtime).
+
+    Notes:
+        The returned key must be discarded after use. It is the caller's
+        responsibility never to log or persist it.
+    """
+    if not master_password:
+        raise ValueError("Master password must not be empty.")
+    if not salt or len(salt) < 16:
+        raise ValueError("Salt must be at least 16 bytes.")
+
+    key = hash_secret_raw(
+        secret=master_password.encode("utf-8"),
+        salt=salt,
+        time_cost=ARGON2_TIME_COST,
+        memory_cost=ARGON2_MEMORY_COST,
+        parallelism=ARGON2_PARALLELISM,
+        hash_len=ARGON2_HASH_LEN,
+        type=ARGON2_TYPE,
+    )
+    return key
+
+
+# ---------------------------------------------------------------------------
+# Encryption
+# ---------------------------------------------------------------------------
+
+def encrypt(plaintext: str, key: bytes) -> tuple[bytes, bytes, bytes]:
+    """
+    Encrypts a plaintext string with AES-256-GCM.
+
+    Args:
+        plaintext: The credential string to encrypt (may be empty, may contain Unicode).
+        key:       A 32-byte AES-256 key (derived via derive_key(), never stored).
+
+    Returns:
+        A 3-tuple: (ciphertext, iv, auth_tag)
+          - iv (nonce): 12 random bytes, unique per call.
+          - ciphertext: the encrypted bytes (without the tag appended).
+          - auth_tag:   16-byte GCM authentication tag.
+
+        These map directly to the VaultEntry model columns:
+          VaultEntry.encrypted_password, VaultEntry.iv, VaultEntry.auth_tag
+
+    Raises:
+        ValueError: If key is not exactly 32 bytes.
+    """
+    if len(key) != 32:
+        raise ValueError("Key must be exactly 32 bytes for AES-256.")
+
+    iv = os.urandom(NONCE_SIZE)  # fresh nonce every call — NEVER reuse
+    aesgcm = AESGCM(key)
+
+    # cryptography library appends the 16-byte tag to the end of the output
+    ciphertext_with_tag = aesgcm.encrypt(iv, plaintext.encode("utf-8"), None)
+
+    # Split off the trailing 16-byte auth tag so each piece maps to its own
+    # database column (matching the VaultEntry model from Task 10).
+    ciphertext = ciphertext_with_tag[:-16]
+    auth_tag   = ciphertext_with_tag[-16:]
+
+    return ciphertext, iv, auth_tag
+
+
+# ---------------------------------------------------------------------------
+# Decryption
+# ---------------------------------------------------------------------------
+
+def decrypt(ciphertext: bytes, iv: bytes, auth_tag: bytes, key: bytes) -> str:
+    """
+    Decrypts AES-256-GCM ciphertext back to a plaintext string.
+
+    Args:
+        ciphertext: The encrypted bytes (VaultEntry.encrypted_password).
+        iv:         The 12-byte nonce used during encryption (VaultEntry.iv).
+        auth_tag:   The 16-byte GCM auth tag (VaultEntry.auth_tag).
+        key:        The 32-byte AES-256 key derived at runtime.
+
+    Returns:
+        The original plaintext string.
+
+    Raises:
+        DecryptionError: If the authentication tag does not verify — caused by
+                         a wrong key, corrupted ciphertext, or tampered auth tag.
+                         No plaintext is returned or logged on failure.
+        ValueError:      If key is not exactly 32 bytes.
+    """
+    if len(key) != 32:
+        raise ValueError("Key must be exactly 32 bytes for AES-256.")
+
+    aesgcm = AESGCM(key)
+    # Reassemble the format the library expects: ciphertext || auth_tag
+    combined = ciphertext + auth_tag
+
+    try:
+        plaintext_bytes = aesgcm.decrypt(iv, combined, None)
+    except Exception:
+        # cryptography raises InvalidTag on auth failure.
+        # We catch broadly and re-raise as DecryptionError to avoid
+        # leaking implementation details or any partial plaintext.
+        raise DecryptionError(
+            "Decryption failed: authentication tag verification error. "
+            "The key may be incorrect or the data may be corrupted."
+        )
+
+    return plaintext_bytes.decode("utf-8")

--- a/backend/tests/test_encryption.py
+++ b/backend/tests/test_encryption.py
@@ -1,0 +1,215 @@
+"""
+Unit tests for Task 14 — AES-256-GCM Encryption Service
+
+Coverage:
+  - encrypt/decrypt round-trip (standard, empty string, Unicode)
+  - Wrong key raises DecryptionError (no plaintext leaked)
+  - Corrupted ciphertext raises DecryptionError
+  - Corrupted auth tag raises DecryptionError
+  - Unique nonce per encryption call (never reused)
+  - Key derivation (Argon2id) produces consistent output for same inputs
+  - Key derivation produces different output for different salts
+  - ValueError on invalid key length
+  - ValueError on empty master password
+"""
+
+import os
+import pytest
+
+from app.services.encryption import (
+    decrypt,
+    derive_key,
+    encrypt,
+    DecryptionError,
+    NONCE_SIZE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_key() -> bytes:
+    """Return a valid random 32-byte key for tests that don't need Argon2."""
+    return os.urandom(32)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+    def test_basic_roundtrip(self):
+        key = make_key()
+        plaintext = "MyS3cretP@ssword!"
+        ciphertext, iv, auth_tag = encrypt(plaintext, key)
+        assert decrypt(ciphertext, iv, auth_tag, key) == plaintext
+
+    def test_empty_string_roundtrip(self):
+        """Empty string is a valid vault entry (e.g. no password stored yet)."""
+        key = make_key()
+        ciphertext, iv, auth_tag = encrypt("", key)
+        assert decrypt(ciphertext, iv, auth_tag, key) == ""
+
+    def test_unicode_roundtrip(self):
+        """Passwords may contain non-ASCII characters."""
+        key = make_key()
+        plaintext = "pässwörD_中文_🔐"
+        ciphertext, iv, auth_tag = encrypt(plaintext, key)
+        assert decrypt(ciphertext, iv, auth_tag, key) == plaintext
+
+    def test_long_password_roundtrip(self):
+        key = make_key()
+        plaintext = "x" * 1024
+        ciphertext, iv, auth_tag = encrypt(plaintext, key)
+        assert decrypt(ciphertext, iv, auth_tag, key) == plaintext
+
+    def test_special_characters_roundtrip(self):
+        key = make_key()
+        plaintext = r"!@#$%^&*()_+-=[]{}|;':\",./<>?"
+        ciphertext, iv, auth_tag = encrypt(plaintext, key)
+        assert decrypt(ciphertext, iv, auth_tag, key) == plaintext
+
+
+# ---------------------------------------------------------------------------
+# Wrong key / corruption tests
+# ---------------------------------------------------------------------------
+
+class TestAuthenticationFailures:
+    def test_wrong_key_raises_decryption_error(self):
+        key_a = make_key()
+        key_b = make_key()  # different key
+        ciphertext, iv, auth_tag = encrypt("secret", key_a)
+        with pytest.raises(DecryptionError):
+            decrypt(ciphertext, iv, auth_tag, key_b)
+
+    def test_corrupted_ciphertext_raises_decryption_error(self):
+        key = make_key()
+        ciphertext, iv, auth_tag = encrypt("secret", key)
+        # Flip a byte in the ciphertext
+        bad_ciphertext = bytes([ciphertext[0] ^ 0xFF]) + ciphertext[1:]
+        with pytest.raises(DecryptionError):
+            decrypt(bad_ciphertext, iv, auth_tag, key)
+
+    def test_corrupted_auth_tag_raises_decryption_error(self):
+        key = make_key()
+        ciphertext, iv, auth_tag = encrypt("secret", key)
+        bad_tag = bytes([auth_tag[0] ^ 0xFF]) + auth_tag[1:]
+        with pytest.raises(DecryptionError):
+            decrypt(ciphertext, iv, bad_tag, key)
+
+    def test_corrupted_iv_raises_decryption_error(self):
+        key = make_key()
+        ciphertext, iv, auth_tag = encrypt("secret", key)
+        bad_iv = bytes([iv[0] ^ 0xFF]) + iv[1:]
+        with pytest.raises(DecryptionError):
+            decrypt(ciphertext, bad_iv, auth_tag, key)
+
+    def test_decryption_error_message_contains_no_plaintext(self):
+        """Ensure error message never leaks the plaintext."""
+        key_a = make_key()
+        key_b = make_key()
+        plaintext = "TopSecretPassword"
+        ciphertext, iv, auth_tag = encrypt(plaintext, key_a)
+        with pytest.raises(DecryptionError) as exc_info:
+            decrypt(ciphertext, iv, auth_tag, key_b)
+        assert plaintext not in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Nonce uniqueness
+# ---------------------------------------------------------------------------
+
+class TestNonceUniqueness:
+    def test_unique_nonce_per_encryption(self):
+        """Each encryption call must produce a different nonce."""
+        key = make_key()
+        plaintext = "same plaintext"
+        results = [encrypt(plaintext, key) for _ in range(100)]
+        ivs = [iv for _, iv, _ in results]
+        # All nonces must be unique
+        assert len(set(ivs)) == 100, "Nonce collision detected — CRITICAL security failure"
+
+    def test_nonce_is_correct_length(self):
+        key = make_key()
+        _, iv, _ = encrypt("test", key)
+        assert len(iv) == NONCE_SIZE  # must be 12 bytes
+
+    def test_auth_tag_is_16_bytes(self):
+        key = make_key()
+        _, _, auth_tag = encrypt("test", key)
+        assert len(auth_tag) == 16
+
+    def test_same_plaintext_different_ciphertext(self):
+        """Same plaintext + key must produce different ciphertext (due to unique nonce)."""
+        key = make_key()
+        ct1, _, _ = encrypt("hello", key)
+        ct2, _, _ = encrypt("hello", key)
+        assert ct1 != ct2
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+class TestInputValidation:
+    def test_encrypt_rejects_short_key(self):
+        with pytest.raises(ValueError):
+            encrypt("hello", b"tooshort")
+
+    def test_decrypt_rejects_short_key(self):
+        key = make_key()
+        ct, iv, tag = encrypt("hello", key)
+        with pytest.raises(ValueError):
+            decrypt(ct, iv, tag, b"tooshort")
+
+
+# ---------------------------------------------------------------------------
+# Key derivation (Argon2id)
+# ---------------------------------------------------------------------------
+
+class TestKeyDerivation:
+    def test_derive_key_is_32_bytes(self):
+        salt = os.urandom(16)
+        key = derive_key("masterpassword", salt)
+        assert len(key) == 32
+
+    def test_derive_key_deterministic(self):
+        """Same password + salt always produces the same key."""
+        salt = os.urandom(16)
+        key1 = derive_key("masterpassword", salt)
+        key2 = derive_key("masterpassword", salt)
+        assert key1 == key2
+
+    def test_derive_key_different_salt_different_key(self):
+        salt1 = os.urandom(16)
+        salt2 = os.urandom(16)
+        key1 = derive_key("masterpassword", salt1)
+        key2 = derive_key("masterpassword", salt2)
+        assert key1 != key2
+
+    def test_derive_key_different_password_different_key(self):
+        salt = os.urandom(16)
+        key1 = derive_key("password1", salt)
+        key2 = derive_key("password2", salt)
+        assert key1 != key2
+
+    def test_derive_key_empty_password_raises(self):
+        with pytest.raises(ValueError):
+            derive_key("", os.urandom(16))
+
+    def test_derive_key_short_salt_raises(self):
+        with pytest.raises(ValueError):
+            derive_key("masterpassword", b"short")
+
+    def test_full_pipeline_with_derived_key(self):
+        """End-to-end: derive key from master password, encrypt, decrypt."""
+        salt = os.urandom(16)
+        key = derive_key("MyMasterP@ss!", salt)
+        plaintext = "github_password_abc123"
+        ciphertext, iv, auth_tag = encrypt(plaintext, key)
+
+        # Re-derive at 'runtime' (simulates what happens on each request)
+        key_rederived = derive_key("MyMasterP@ss!", salt)
+        result = decrypt(ciphertext, iv, auth_tag, key_rederived)
+        assert result == plaintext


### PR DESCRIPTION
Implements AES-256-GCM encryption service for vault entries.

- app/services/encryption.py — encrypt(), decrypt(), derive_key()
- tests/test_encryption.py — 23 unit tests
- encrypt() returns (ciphertext, iv, auth_tag) matching VaultEntry model columns
- decrypt() raises DecryptionError on wrong key or corrupted data
- derive_key() uses Argon2id with OWASP parameters (64MiB, 3 iter, p=4)
- Key never stored — derived at runtime only
- No plaintext ever written to logs or error messages
- 20 unit tests covering round-trips, wrong key, nonce uniqueness, Unicode

Key decisions: nonce/iv returned separately to match VaultEntry model columns. DecryptionError raised on any tag failure without leaking plaintext.

Closes #14 